### PR TITLE
query fix to ordered by time. query "or" to "and".

### DIFF
--- a/lib/Iyemon/Web.pm
+++ b/lib/Iyemon/Web.pm
@@ -39,10 +39,11 @@ get '/search' => sub {
 
     my $strp = DateTime::Format::Strptime->new(pattern => '%Y-%m-%dT%H:%M');
     push @where, (
-        time => {
-            ">=" => $strp->parse_datetime($start_date)->epoch,
-            "<=" => $strp->parse_datetime($end_date)->epoch,
-        },
+        time => [
+            "-and",
+            { ">=" => $strp->parse_datetime($start_date)->epoch },
+            { "<=" => $strp->parse_datetime($end_date)->epoch },
+        ],
     );
 
     my $page  = $c->req->param("page");
@@ -51,7 +52,7 @@ get '/search' => sub {
     my ($sql, @binds) = sql_maker->select("action_logs",
         ["uid", "time", "type", "json"],
         \@where,
-        {limit => $limit, offset => $limit - 100},
+        {order_by => "time", limit => $limit, offset => $limit - 100},
     );
 
     my ($rows) = handler->dbh->selectall_arrayref($sql, {Slice => {}}, @binds);


### PR DESCRIPTION
一部非互換の修正なので相談したいです。
1. timeで時系列順に並ぶようにした こいつが非互換です
2. 時間帯を絞り込むクエリでtimeの片側だけしかSQL::Makerから吐かれていなかったのでAND指定するようにした
